### PR TITLE
Suggest using half-width Katakana

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -1,7 +1,7 @@
 var Drop = function (x, canvas, ctx, fontSize) {
     /* A pool of characters that are used for the threads */
     var charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" +
-                  "畀畁畂畃畄畅畆畇畈畉畊畋界畍畎畏畐畑";
+                  "ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝｦ";
     this.charset = charset.split("");
 
     this.canvas = canvas;


### PR DESCRIPTION
As a Chinese-writing person I found the drop using some Chinese characters weird.
I suggest using half-width Katakana as the characters, since Matrix does so (but these are horizontally-inverted in Matrix film.)
